### PR TITLE
Fix reading of `odometry.csv`

### DIFF
--- a/stray_visualize.py
+++ b/stray_visualize.py
@@ -47,8 +47,8 @@ def read_data(flags):
 
     for line in odometry:
         # x, y, z, qx, qy, qz, qw
-        position = line[:3]
-        quaternion = line[3:]
+        position = line[2:5]
+        quaternion = line[5:]
         T_WC = np.eye(4)
         T_WC[:3, :3] = Rotation.from_quat(quaternion).as_matrix()
         T_WC[:3, 3] = position


### PR DESCRIPTION
The first two items from `odometry.csv` should be discarded, since the file is organized as
```csv
timestamp, frame, x, y, z, qx, qy, qz, w
```
The indices of each camera position should be `[2:5]`, and the indices of each quaternion should be `[5:]`.

Signed-off-by: Gaoyang Zhang <gy@blurgy.xyz>